### PR TITLE
fix: remove non-functional --db option from monitor command

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -148,10 +148,6 @@ pub enum Commands {
         #[arg(long)]
         hashrate_alert: Option<f64>,
 
-        /// Save data to SQLite database
-        #[arg(long)]
-        db: Option<PathBuf>,
-
         /// Monitor only devices of a specific type
         #[arg(long, value_name = "TYPE")]
         device_type: Option<DeviceFilterArg>,
@@ -381,7 +377,6 @@ impl Cli {
                 interval,
                 temp_alert,
                 hashrate_alert,
-                db,
                 device_type,
                 type_summary,
             } => {
@@ -389,7 +384,6 @@ impl Cli {
                     interval,
                     temp_alert,
                     hashrate_alert,
-                    db,
                     type_filter: device_type,
                     type_summary,
                     format: self.format,

--- a/src/cli/commands/handlers/monitor.rs
+++ b/src/cli/commands/handlers/monitor.rs
@@ -1,7 +1,7 @@
 use crate::cli::commands::{DeviceFilterArg, OutputFormat};
 use anyhow::Result;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -9,7 +9,6 @@ pub struct MonitorConfig<'a> {
     pub interval: u64,
     pub temp_alert: Option<f64>,
     pub hashrate_alert: Option<f64>,
-    pub db: Option<PathBuf>,
     pub type_filter: Option<DeviceFilterArg>,
     pub type_summary: bool,
     pub format: OutputFormat,


### PR DESCRIPTION
## Summary
- Removes the non-functional `--db` parameter from the monitor command
- Cleans up unused database-related code

## Changes
This PR removes the `--db` option that was present in the monitor command but never actually implemented. The option was accepting a path to a SQLite database file but had no backing functionality.

### Specific changes:
1. **Removed `--db` parameter** from the Monitor command in `src/cli/commands.rs`
2. **Removed `db` field** from the `MonitorConfig` struct in `src/cli/commands/handlers/monitor.rs`
3. **Cleaned up imports** by removing unused `PathBuf` import in monitor.rs
4. **Updated command invocation** to no longer pass the db parameter

## Test plan
- [x] Code compiles successfully with `cargo build`
- [x] All tests pass with `cargo test`
- [x] Clippy checks pass with `cargo clippy`
- [x] Code is properly formatted with `cargo fmt --check`
- [x] Monitor command works correctly without the --db option

## Breaking changes
None - this removes a non-functional option that was never actually used.