### PR TITLE
fix: add CDLA-Permissive-2.0 license to allowed list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "Zlib",
+    "CDLA-Permissive-2.0",  # Required by webpki-roots (reqwest dependency)
 ]
 
 [bans]


### PR DESCRIPTION
## Summary
- Fixes Supply Chain Security CI check by adding CDLA-Permissive-2.0 license to the allowed list
- This license is required by webpki-roots v1.0.2, a transitive dependency of reqwest through hyper-rustls

## Context
The Supply Chain Security check was failing with:
```
error[rejected]: failed to satisfy license requirements
   ┌─ webpki-roots v1.0.2
   │ license = "CDLA-Permissive-2.0"
   │            rejected: license is not explicitly allowed
```

## Changes
- Added `CDLA-Permissive-2.0` to the allowed licenses list in `deny.toml`
- This is a permissive license that's compatible with our project's licensing

## Test Plan
- [x] `cargo deny check` passes
- [x] All CI checks should now pass