### PR TITLE
docs: add comprehensive comments for terminal cleanup RAII pattern

### DIFF
--- a/src/cli/commands/handlers/list.rs
+++ b/src/cli/commands/handlers/list.rs
@@ -77,29 +77,49 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
     };
     use std::collections::HashMap;
 
-    // Set up alternate screen for watch mode to prevent flicker
+    // Set up alternate screen for watch mode to prevent flicker.
+    // The alternate screen is a separate buffer that doesn't affect the main terminal scrollback.
+    // We only use it in watch mode since normal list output should remain in the terminal history.
     let use_alternate_screen = args.watch && matches!(args.format, OutputFormat::Text);
 
     if use_alternate_screen {
         let mut stdout_handle = stdout();
+        // EnterAlternateScreen: Switch to a separate screen buffer (like vim or less does)
+        // Hide: Hide the cursor for cleaner display during updates
         execute!(stdout_handle, EnterAlternateScreen, Hide)?;
     }
 
-    // Ensure we clean up on exit
+    // Define a local RAII guard that will automatically restore the terminal when dropped.
+    // RAII (Resource Acquisition Is Initialization) ensures cleanup happens automatically.
     struct CleanupGuard {
         use_alternate_screen: bool,
     }
 
+    // The Drop trait is Rust's destructor mechanism. This code runs automatically
+    // when the CleanupGuard instance is destroyed (goes out of scope).
     impl Drop for CleanupGuard {
         fn drop(&mut self) {
             if self.use_alternate_screen {
                 let mut stdout_handle = stdout();
+                // Restore the terminal to its original state:
+                // - LeaveAlternateScreen: Switch back to the main terminal buffer
+                // - Show: Make the cursor visible again
+                // We use `let _ =` to explicitly ignore errors because:
+                // 1. We're in a destructor, so we can't propagate errors
+                // 2. We want cleanup to be best-effort
+                // 3. The terminal will reset when the process ends anyway
                 let _ = execute!(stdout_handle, LeaveAlternateScreen, Show);
                 let _ = stdout_handle.flush();
             }
         }
     }
 
+    // Create the guard. The underscore prefix (_cleanup) tells Rust we won't use this variable,
+    // but we want to keep it alive until the function ends.
+    // This guard ensures the terminal is restored even if:
+    // - The function returns early with an error (? operator)
+    // - The user presses Ctrl+C
+    // - The program panics
     let _cleanup = CleanupGuard {
         use_alternate_screen,
     };


### PR DESCRIPTION
## Summary
Adds detailed documentation to explain the RAII cleanup pattern used for terminal restoration in monitor and list commands. This helps new developers understand this important safety mechanism.

## Why This Is Important
The terminal cleanup code uses Rust's RAII pattern which may be unfamiliar to developers coming from other languages. Without proper documentation, it's not immediately clear:
- Why we need this pattern
- What could go wrong without it
- How it ensures safety even during panics
- What the underscore prefix means

## Changes
Added comprehensive comments to explain:
- **What RAII means**: Resource Acquisition Is Initialization pattern
- **Alternate screen buffer**: Why we use it (prevents scrollback pollution)
- **Drop trait behavior**: Automatic destructor-like mechanism in Rust
- **Variable naming**: Why `_cleanup` has an underscore prefix
- **Error handling**: Why errors are ignored in Drop implementation
- **Execution guarantees**: When cleanup runs (panic, early return, normal exit)
- **Terminal commands**: What each command does (EnterAlternateScreen, Hide, etc.)

## Files Modified
- `src/cli/commands/handlers/monitor_async.rs`
- `src/cli/commands/handlers/monitor.rs`
- `src/cli/commands/handlers/list.rs`

## Benefits
- Makes the codebase more accessible to new contributors
- Reduces the learning curve for Rust-specific patterns
- Prevents future mistakes by clearly documenting the pattern
- Serves as inline documentation for terminal handling best practices

## Example of Added Documentation
```rust
// The Drop trait is Rust's destructor mechanism. This code runs automatically
// when the CleanupGuard instance is destroyed (goes out of scope).
impl Drop for CleanupGuard {
    fn drop(&mut self) {
        if self.use_alternate_screen {
            // Restore the terminal to its original state:
            // - LeaveAlternateScreen: Switch back to the main terminal buffer
            // - Show: Make the cursor visible again
            // We use `let _ =` to explicitly ignore errors because:
            // 1. We're in a destructor, so we can't propagate errors
            // 2. We want cleanup to be best-effort
            // 3. The terminal will reset when the process ends anyway
            let _ = execute\!(stdout_handle, LeaveAlternateScreen, Show);
        }
    }
}
```

This is a documentation-only change with no functional modifications.