### PR TITLE
fix: use Nix to run cargo-audit and cargo-deny in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,12 @@ jobs:
           ~/.cargo/git
         key: audit-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
     - name: Run security audit
-      run: cargo audit
+      run: nix run nixpkgs#cargo-audit -- audit
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,14 +32,17 @@ jobs:
           ~/.cargo/git
         key: audit-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
     - name: Run cargo audit
-      run: cargo audit
+      run: nix run nixpkgs#cargo-audit -- audit
 
     - name: Run cargo audit (JSON output)
-      run: cargo audit --json > audit-results.json
+      run: nix run nixpkgs#cargo-audit -- audit --json > audit-results.json
       continue-on-error: true
 
     - name: Upload audit results
@@ -68,11 +71,14 @@ jobs:
           ~/.cargo/git
         key: supply-chain-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Install cargo-deny
-      run: cargo install cargo-deny
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
 
     - name: Run cargo deny
-      run: cargo deny check
+      run: nix run nixpkgs#cargo-deny -- check
 
   codeql-analysis:
     name: CodeQL Analysis


### PR DESCRIPTION
## Summary
- Replace `cargo install` with Nix commands to fix CI failures
- Avoids compilation issues with crc32fast v1.5.0 dependency
- Uses pre-built binaries from nixpkgs for faster CI runs

## Problem
The CI workflows were failing because `cargo install` attempts to compile `cargo-audit` and `cargo-deny` from source, but these tools depend on `crc32fast` v1.5.0 which has compilation errors with duplicate function definitions.

## Solution
Use Nix to run these tools instead of compiling from source:
- `cargo-audit` v0.21.2 via nixpkgs
- `cargo-deny` v0.18.4 via nixpkgs

## Changes
- Updated `.github/workflows/security.yml` to use `nix run nixpkgs#cargo-audit` and `nix run nixpkgs#cargo-deny`
- Updated `.github/workflows/ci.yml` to use `nix run nixpkgs#cargo-audit`
- Added Nix installation step before running these tools

## Benefits
- Fixes immediate CI failures
- Faster CI runs (pre-built binaries instead of compilation)
- More reliable than source compilation
- Consistent with project's Nix-based tooling

## Test Plan
- [x] Tested cargo-audit locally with Nix
- [x] Tested cargo-deny locally with Nix
- [ ] CI workflows should pass after merge