### PR TITLE
feat: add release binaries workflow and bootstrap script

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,305 @@
+name: Release Binaries
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write  # Required for creating releases
+
+jobs:
+  build-linux:
+    name: Build Linux Binaries
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 Linux
+      run: |
+        nix develop -c cargo build --release
+        mkdir -p artifacts/linux-x86_64
+        cp target/x86_64-unknown-linux-musl/release/axectl artifacts/linux-x86_64/axectl
+        chmod +x artifacts/linux-x86_64/axectl
+    
+    - name: Create checksums
+      run: |
+        cd artifacts
+        for dir in */; do
+          (cd "$dir" && sha256sum axectl > axectl.sha256)
+        done
+    
+    - name: Create tarball archives
+      run: |
+        cd artifacts
+        for dir in */; do
+          dirname="${dir%/}"
+          tar czf "axectl-${dirname}.tar.gz" "$dirname"
+        done
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: axectl-linux-binaries
+        path: artifacts/*.tar.gz
+        retention-days: 90
+
+  build-macos:
+    name: Build macOS Binaries
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-apple-darwin,aarch64-apple-darwin
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 macOS
+      run: |
+        cargo build --release --target x86_64-apple-darwin
+        mkdir -p artifacts/macos-x86_64
+        cp target/x86_64-apple-darwin/release/axectl artifacts/macos-x86_64/axectl
+        chmod +x artifacts/macos-x86_64/axectl
+    
+    - name: Build ARM64 macOS (Apple Silicon)
+      run: |
+        cargo build --release --target aarch64-apple-darwin
+        mkdir -p artifacts/macos-aarch64
+        cp target/aarch64-apple-darwin/release/axectl artifacts/macos-aarch64/axectl
+        chmod +x artifacts/macos-aarch64/axectl
+    
+    - name: Create checksums
+      run: |
+        cd artifacts
+        for dir in */; do
+          (cd "$dir" && shasum -a 256 axectl > axectl.sha256)
+        done
+    
+    - name: Create tarball archives
+      run: |
+        cd artifacts
+        for dir in */; do
+          dirname="${dir%/}"
+          tar czf "axectl-${dirname}.tar.gz" "$dirname"
+        done
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: axectl-macos-binaries
+        path: artifacts/*.tar.gz
+        retention-days: 90
+
+  build-windows:
+    name: Build Windows Binaries
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-pc-windows-msvc
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 Windows
+      run: |
+        cargo build --release --target x86_64-pc-windows-msvc
+        New-Item -ItemType Directory -Force -Path artifacts/windows-x86_64
+        Copy-Item target/x86_64-pc-windows-msvc/release/axectl.exe artifacts/windows-x86_64/axectl.exe
+    
+    - name: Create checksums
+      shell: powershell
+      run: |
+        cd artifacts
+        Get-ChildItem -Directory | ForEach-Object {
+          cd $_.Name
+          $hash = Get-FileHash -Algorithm SHA256 axectl.exe
+          "$($hash.Hash.ToLower())  axectl.exe" | Out-File -Encoding ASCII axectl.sha256
+          cd ..
+        }
+    
+    - name: Create ZIP archives
+      shell: powershell
+      run: |
+        cd artifacts
+        Get-ChildItem -Directory | ForEach-Object {
+          Compress-Archive -Path $_.FullName -DestinationPath "axectl-$($_.Name).zip"
+        }
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: axectl-windows-binaries
+        path: artifacts/*.zip
+        retention-days: 90
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-linux, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v5
+      with:
+        path: release-artifacts
+    
+    - name: Get short SHA
+      id: sha
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    
+    - name: Get date
+      id: date
+      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+    
+    - name: Prepare release files
+      run: |
+        mkdir -p release-files
+        mv release-artifacts/axectl-linux-binaries/* release-files/
+        mv release-artifacts/axectl-macos-binaries/* release-files/
+        mv release-artifacts/axectl-windows-binaries/* release-files/
+        
+        # Add the bootstrap script
+        cp axectl.sh release-files/
+        chmod +x release-files/axectl.sh
+        
+        ls -la release-files/
+    
+    - name: Create release notes
+      run: |
+        cat > release-notes.md << EOF
+        ## axectl Latest Build (master branch)
+        
+        **Build Date:** $(date +'%Y-%m-%d %H:%M:%S UTC')
+        **Commit:** ${{ steps.sha.outputs.sha_short }}
+        
+        ### Available Binaries
+        
+        #### Linux
+        - \`axectl-linux-x86_64.tar.gz\` - Static musl binary (works on all Linux distros)
+        
+        #### macOS
+        - \`axectl-macos-x86_64.tar.gz\` - Intel Mac binary
+        - \`axectl-macos-aarch64.tar.gz\` - Apple Silicon (M1/M2/M3) binary
+        
+        #### Windows
+        - \`axectl-windows-x86_64.zip\` - Windows 64-bit executable
+        
+        ### Installation
+        
+        #### Quick Install (Using Bootstrap Script)
+        
+        Download and use \`axectl.sh\` for automatic installation and updates:
+        
+        \`\`\`bash
+        curl -L https://github.com/douglaz/axectl/releases/download/latest-master/axectl.sh -o axectl.sh
+        chmod +x axectl.sh
+        ./axectl.sh --help
+        \`\`\`
+        
+        The bootstrap script will:
+        - Automatically detect your platform
+        - Download the appropriate binary
+        - Extract and install to \`~/.local/bin\`
+        - Check for updates periodically
+        - Use local builds when available (for development)
+        
+        #### Manual Installation
+        
+        1. Download the appropriate binary for your platform
+        2. Extract the archive
+        3. Make the binary executable (Linux/macOS): \`chmod +x axectl\`
+        4. Optionally move to your PATH: \`sudo mv axectl /usr/local/bin/\`
+        
+        ### Verify Checksums
+        
+        Each archive contains a \`.sha256\` file with the binary's checksum.
+        
+        \`\`\`bash
+        # Linux/macOS
+        sha256sum -c axectl.sha256
+        
+        # Windows (PowerShell)
+        Get-FileHash axectl.exe -Algorithm SHA256
+        \`\`\`
+        
+        ### Features
+        
+        - **Auto-Discovery**: mDNS and network scanning for AxeOS devices
+        - **Device Monitoring**: Real-time hashrate, temperature, and power metrics
+        - **Device Control**: Fan speed, restart, and configuration management
+        - **Multi-Device Support**: Bitaxe and NerdQAxe compatibility
+        - **JSON Output**: Machine-readable format for automation
+        
+        ---
+        *This is an automated build from the master branch. For stable releases, see the Releases page.*
+        EOF
+    
+    - name: Delete existing latest release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Delete the release if it exists
+        gh release delete latest-master --yes 2>/dev/null || true
+        
+        # Delete the tag if it exists
+        git push --delete origin latest-master 2>/dev/null || true
+    
+    - name: Create new release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create latest-master \
+          --title "Latest Build (master)" \
+          --notes-file release-notes.md \
+          --prerelease \
+          release-files/*

--- a/axectl.sh
+++ b/axectl.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configuration
+REPO="douglaz/axectl"
+BINARY_NAME="axectl"
+INSTALL_DIR="${HOME}/.local/bin"
+INSTALLED_VERSION_FILE="${INSTALL_DIR}/.${BINARY_NAME}.version"
+# Determine script directory (only available when run as a file, not via stdin)
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+    SCRIPT_DIR=""
+fi
+
+# Platform detection
+detect_platform() {
+    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    local arch=$(uname -m)
+    
+    case "$os" in
+        linux)
+            case "$arch" in
+                x86_64) echo "linux-x86_64" ;;
+                aarch64) echo "linux-aarch64" ;;
+                *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+            esac
+            ;;
+        darwin)
+            case "$arch" in
+                x86_64) echo "macos-x86_64" ;;
+                arm64) echo "macos-aarch64" ;;
+                *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+            esac
+            ;;
+        mingw*|msys*|cygwin*)
+            case "$arch" in
+                x86_64) echo "windows-x86_64" ;;
+                *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+            esac
+            ;;
+        *) echo "Unsupported OS: $os" >&2; exit 1 ;;
+    esac
+}
+
+# Get latest release version from GitHub
+get_latest_version() {
+    # Get the latest release (including pre-releases since they pass CI)
+    local releases=$(curl -s "https://api.github.com/repos/$REPO/releases" 2>/dev/null)
+    
+    # Check if jq is available for proper JSON parsing
+    if command -v jq >/dev/null 2>&1; then
+        # Check if the response is an array (successful) or an object (error/rate limit)
+        local is_array=$(echo "$releases" | jq -r 'if type == "array" then "yes" else "no" end' 2>/dev/null)
+        if [[ "$is_array" == "yes" ]]; then
+            local latest_version=$(echo "$releases" | jq -r '.[0].tag_name // empty' 2>/dev/null)
+            if [[ -n "$latest_version" ]]; then
+                echo "$latest_version"
+                return
+            fi
+        fi
+    else
+        # Fallback to grep-based parsing (less reliable but works without jq)
+        # Get the first tag_name from the JSON response
+        local tag_name=$(echo "$releases" | grep -m1 '"tag_name":' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+        if [[ -n "$tag_name" ]]; then
+            echo "$tag_name"
+            return
+        fi
+    fi
+    
+    # Fall back to latest-master if API call fails or no releases found
+    echo "latest-master"
+}
+
+# Get currently installed version
+get_installed_version() {
+    if [[ -f "$INSTALLED_VERSION_FILE" ]]; then
+        cat "$INSTALLED_VERSION_FILE"
+    else
+        echo "none"
+    fi
+}
+
+# Download and install binary
+install_binary() {
+    local version="$1"
+    local platform="$2"
+    
+    echo "Downloading ${BINARY_NAME} ${version} for ${platform}..." >&2
+    
+    # Create install directory if it doesn't exist
+    mkdir -p "$INSTALL_DIR"
+    
+    # Determine file extension based on platform
+    local ext="tar.gz"
+    if [[ "$platform" == windows-* ]]; then
+        ext="zip"
+    fi
+    
+    # Construct download URL
+    local url="https://github.com/${REPO}/releases/download/${version}/${BINARY_NAME}-${platform}.${ext}"
+    
+    # Download to temporary file
+    local temp_file=$(mktemp)
+    if ! curl -sL -o "$temp_file" "$url"; then
+        rm -f "$temp_file"
+        echo "Failed to download ${BINARY_NAME}" >&2
+        exit 1
+    fi
+    
+    # Extract the archive
+    local temp_dir=$(mktemp -d)
+    if [[ "$ext" == "zip" ]]; then
+        unzip -q "$temp_file" -d "$temp_dir"
+    else
+        tar -xzf "$temp_file" -C "$temp_dir"
+    fi
+    rm -f "$temp_file"
+    
+    # Find and move the binary
+    # The archive contains just the platform directory (e.g., linux-x86_64/)
+    local binary_path="${temp_dir}/${platform}/${BINARY_NAME}"
+    if [[ "$platform" == windows-* ]]; then
+        binary_path="${temp_dir}/${platform}/${BINARY_NAME}.exe"
+    fi
+    
+    if [[ ! -f "$binary_path" ]]; then
+        echo "Error: Binary not found in archive" >&2
+        rm -rf "$temp_dir"
+        exit 1
+    fi
+    
+    # Make executable and move to install directory
+    chmod +x "$binary_path"
+    mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+    rm -rf "$temp_dir"
+    
+    # Record installed version
+    echo "$version" > "$INSTALLED_VERSION_FILE"
+    
+    echo "${BINARY_NAME} ${version} installed successfully" >&2
+}
+
+# Check for updates periodically (once per day)
+should_check_update() {
+    local check_file="${INSTALL_DIR}/.${BINARY_NAME}.last_check"
+    
+    # Always check if binary doesn't exist
+    if [[ ! -f "${INSTALL_DIR}/${BINARY_NAME}" ]]; then
+        return 0
+    fi
+    
+    # Check if we've checked recently
+    if [[ -f "$check_file" ]]; then
+        local last_check=$(stat -c %Y "$check_file" 2>/dev/null || stat -f %m "$check_file" 2>/dev/null || echo 0)
+        local current_time=$(date +%s)
+        local day_in_seconds=86400
+        
+        if (( current_time - last_check < day_in_seconds )); then
+            return 1
+        fi
+    fi
+    
+    # Mark that we're checking now
+    touch "$check_file"
+    return 0
+}
+
+
+# Main logic
+main() {
+    # First, check if we're in the repository and can run locally
+    if [[ -n "$SCRIPT_DIR" && -d "${SCRIPT_DIR}/.git" ]]; then
+        # Check if we have a local build
+        local local_binary="${SCRIPT_DIR}/target/release/${BINARY_NAME}"
+        if [[ ! -f "$local_binary" ]]; then
+            local_binary="${SCRIPT_DIR}/target/x86_64-unknown-linux-musl/release/${BINARY_NAME}"
+        fi
+        
+        if [[ -f "$local_binary" ]]; then
+            # Use local build directly
+            exec "$local_binary" "$@"
+        fi
+    fi
+    
+    local platform=$(detect_platform)
+    
+    # Check if we should look for updates
+    if should_check_update; then
+        local latest_version=$(get_latest_version)
+        
+        if [[ -n "$latest_version" ]]; then
+            local installed_version=$(get_installed_version)
+            
+            if [[ "$latest_version" != "$installed_version" ]]; then
+                echo "New version available: ${latest_version} (installed: ${installed_version})" >&2
+                install_binary "$latest_version" "$platform"
+            fi
+        fi
+    fi
+    
+    # Check if binary exists in install dir
+    if [[ -f "${INSTALL_DIR}/${BINARY_NAME}" ]]; then
+        exec "${INSTALL_DIR}/${BINARY_NAME}" "$@"
+    fi
+    
+    # No installed binary - try to download latest release
+    local latest_version=$(get_latest_version)
+    if [[ -n "$latest_version" ]]; then
+        echo "Installing axectl ${latest_version}..." >&2
+        install_binary "$latest_version" "$platform"
+        
+        # After successful install, run the binary
+        if [[ -f "${INSTALL_DIR}/${BINARY_NAME}" ]]; then
+            exec "${INSTALL_DIR}/${BINARY_NAME}" "$@"
+        fi
+    fi
+    
+    # No releases available
+    echo "Error: No axectl releases available for download." >&2
+    echo "Please check https://github.com/${REPO}/releases" >&2
+    exit 1
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
Adds automated release binary builds and a bootstrap script for easy installation, similar to cyberkrill's setup.

## Features Added

### Bootstrap Script (`axectl.sh`)
- Auto-detects platform (Linux/macOS/Windows)
- Downloads the appropriate binary automatically
- Installs to `~/.local/bin`
- Checks for updates daily
- Uses local builds when available (for development)

### Release Binaries Workflow
- Builds binaries for all major platforms:
  - **Linux**: Static musl binary (works on all distros)
  - **macOS**: Intel (x86_64) and Apple Silicon (aarch64)
  - **Windows**: 64-bit executable
- Automatically creates GitHub releases on master branch pushes
- Includes checksums for verification
- Pre-release tagged as `latest-master`

## Installation Usage

After this is merged, users can install axectl with:

```bash
# Download and run the bootstrap script
curl -L https://github.com/douglaz/axectl/releases/download/latest-master/axectl.sh -o axectl.sh
chmod +x axectl.sh
./axectl.sh --help
```

The script will:
1. Detect the user's platform
2. Download the correct binary
3. Install it to `~/.local/bin`
4. Check for updates automatically

## Benefits
- Easy installation for users (single script)
- Cross-platform support
- Automatic updates
- No need to compile from source
- Consistent with cyberkrill's UX

## Test Plan
- [ ] Workflow runs successfully on merge
- [ ] Binaries are created for all platforms
- [ ] Bootstrap script downloads and runs correctly
- [ ] Update checking works as expected