### PR TITLE
chore: migrate to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "axectl"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "CLI tool for managing Bitaxe and NerdQAxe miners"
 license = "MIT"
 repository = "https://github.com/master/axectl"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use reqwest::{Client, ClientBuilder};
 use std::time::Duration;
 use url::Url;
@@ -490,9 +490,11 @@ mod tests {
 
         mock.assert_async().await;
         assert!(result.success);
-        assert!(result
-            .message
-            .contains("System settings updated successfully"));
+        assert!(
+            result
+                .message
+                .contains("System settings updated successfully")
+        );
     }
 
     #[tokio::test]

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -1075,14 +1075,20 @@ mod tests {
 
         // Should only include types that have devices
         assert_eq!(summaries.len(), 2);
-        assert!(summaries
-            .iter()
-            .any(|s| s.device_type == DeviceType::BitaxeMax));
-        assert!(summaries
-            .iter()
-            .any(|s| s.device_type == DeviceType::NerdqaxePlus));
-        assert!(!summaries
-            .iter()
-            .any(|s| s.device_type == DeviceType::BitaxeUltra));
+        assert!(
+            summaries
+                .iter()
+                .any(|s| s.device_type == DeviceType::BitaxeMax)
+        );
+        assert!(
+            summaries
+                .iter()
+                .any(|s| s.device_type == DeviceType::NerdqaxePlus)
+        );
+        assert!(
+            !summaries
+                .iter()
+                .any(|s| s.device_type == DeviceType::BitaxeUltra)
+        );
     }
 }

--- a/src/cli/commands/handlers/bulk.rs
+++ b/src/cli/commands/handlers/bulk.rs
@@ -192,14 +192,13 @@ fn filter_devices(
 
     // Filter by IP addresses
     for ip_address in ip_addresses {
-        if let Some(cached) = cache.get_device(ip_address) {
-            if cached.device.status == DeviceStatus::Online
-                && !devices
-                    .iter()
-                    .any(|d: &Device| d.ip_address == cached.device.ip_address)
-            {
-                devices.push(cached.device.clone());
-            }
+        if let Some(cached) = cache.get_device(ip_address)
+            && cached.device.status == DeviceStatus::Online
+            && !devices
+                .iter()
+                .any(|d: &Device| d.ip_address == cached.device.ip_address)
+        {
+            devices.push(cached.device.clone());
         }
     }
 

--- a/src/cli/commands/handlers/control.rs
+++ b/src/cli/commands/handlers/control.rs
@@ -11,7 +11,7 @@ pub async fn control(
     cache_dir: Option<&Path>,
 ) -> Result<()> {
     use crate::api::{AxeOsClient, SystemUpdateRequest};
-    use crate::cache::{get_cache_dir, DeviceCache};
+    use crate::cache::{DeviceCache, get_cache_dir};
     use crate::output::{print_error, print_info, print_json, print_success};
 
     // Get cache directory, using default if not provided
@@ -115,20 +115,20 @@ pub async fn control(
             OutputFormat::Text => {
                 if command_result.success {
                     print_success(&command_result.message, color);
-                    if let Some(data) = &command_result.data {
-                        if let Some(networks) = data.get("networks") {
-                            println!("WiFi Networks:");
-                            if let Some(networks_array) = networks.as_array() {
-                                for network in networks_array {
-                                    if let (Some(ssid), Some(rssi)) =
-                                        (network.get("ssid"), network.get("rssi"))
-                                    {
-                                        println!(
-                                            "  {} ({}dBm)",
-                                            ssid.as_str().unwrap_or("Unknown"),
-                                            rssi.as_i64().unwrap_or(0)
-                                        );
-                                    }
+                    if let Some(data) = &command_result.data
+                        && let Some(networks) = data.get("networks")
+                    {
+                        println!("WiFi Networks:");
+                        if let Some(networks_array) = networks.as_array() {
+                            for network in networks_array {
+                                if let (Some(ssid), Some(rssi)) =
+                                    (network.get("ssid"), network.get("rssi"))
+                                {
+                                    println!(
+                                        "  {} ({}dBm)",
+                                        ssid.as_str().unwrap_or("Unknown"),
+                                        rssi.as_i64().unwrap_or(0)
+                                    );
                                 }
                             }
                         }

--- a/src/cli/commands/handlers/discovery.rs
+++ b/src/cli/commands/handlers/discovery.rs
@@ -103,13 +103,11 @@ pub async fn perform_discovery(
             for ip in &known_ips {
                 if let Ok(Some(device)) =
                     scanner::probe_single_device(ip, Duration::from_millis(500)).await
-                {
-                    if !all_devices
+                    && !all_devices
                         .iter()
                         .any(|d| d.ip_address == device.ip_address)
-                    {
-                        all_devices.push(device);
-                    }
+                {
+                    all_devices.push(device);
                 }
             }
 

--- a/src/cli/commands/handlers/list.rs
+++ b/src/cli/commands/handlers/list.rs
@@ -6,7 +6,7 @@ use crossterm::{
     execute,
     terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use std::io::{stdout, Write as IoWrite};
+use std::io::{Write as IoWrite, stdout};
 use std::path::Path;
 use std::time::Duration;
 use tabled::Tabled;
@@ -73,8 +73,8 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
     use crate::api::{DeviceStatus, SwarmSummary};
     use crate::cache::DeviceCache;
     use crate::output::{
-        format_hashrate, format_power, format_table, format_uptime, print_info, print_json,
-        print_success, print_warning, ColoredTemperature,
+        ColoredTemperature, format_hashrate, format_power, format_table, format_uptime, print_info,
+        print_json, print_success, print_warning,
     };
     use std::collections::HashMap;
 
@@ -232,13 +232,13 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
                             // Check for alerts if in watch mode
                             if args.watch {
                                 // Temperature alert
-                                if let Some(temp_threshold) = args.temp_alert {
-                                    if stats.temperature_celsius > temp_threshold {
-                                        alerts.push(format!(
-                                            "🌡️ {} temperature alert: {:.1}°C > {:.1}°C",
-                                            device.name, stats.temperature_celsius, temp_threshold
-                                        ));
-                                    }
+                                if let Some(temp_threshold) = args.temp_alert
+                                    && stats.temperature_celsius > temp_threshold
+                                {
+                                    alerts.push(format!(
+                                        "🌡️ {} temperature alert: {:.1}°C > {:.1}°C",
+                                        device.name, stats.temperature_celsius, temp_threshold
+                                    ));
                                 }
 
                                 // Hashrate drop alert
@@ -557,7 +557,10 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
                     } else if let Some(ref mut buffer) = output_buffer {
                         writeln!(buffer)?;
                         writeln!(buffer, "📊 Device Type Summaries:")?;
-                        writeln!(buffer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")?;
+                        writeln!(
+                            buffer,
+                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                        )?;
 
                         let type_summaries = cache.get_type_summaries();
                         if type_summaries.is_empty() {
@@ -586,7 +589,9 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
                     } else {
                         println!();
                         println!("📊 Device Type Summaries:");
-                        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+                        println!(
+                            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                        );
 
                         let type_summaries = cache.get_type_summaries();
                         if type_summaries.is_empty() {
@@ -661,10 +666,11 @@ pub async fn list(args: ListArgs<'_>) -> Result<()> {
         }
 
         // Save cache if we updated stats
-        if !args.no_stats && !device_stats.is_empty() {
-            if let Err(e) = cache.save(cache_path) {
-                tracing::warn!("Failed to save cache: {}", e);
-            }
+        if !args.no_stats
+            && !device_stats.is_empty()
+            && let Err(e) = cache.save(cache_path)
+        {
+            tracing::warn!("Failed to save cache: {}", e);
         }
 
         if !matches!(args.format, OutputFormat::Json) {

--- a/src/cli/commands/handlers/mod.rs
+++ b/src/cli/commands/handlers/mod.rs
@@ -8,6 +8,6 @@ pub mod monitor_async;
 pub use bulk::bulk;
 pub use control::control;
 pub use discovery::discover;
-pub use list::{list, ListArgs};
+pub use list::{ListArgs, list};
 pub use monitor::monitor;
 pub use monitor_async::monitor_async;

--- a/src/cli/commands/handlers/monitor.rs
+++ b/src/cli/commands/handlers/monitor.rs
@@ -6,7 +6,7 @@ use crossterm::{
     terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use std::collections::HashMap;
-use std::io::{stdout, Write as IoWrite};
+use std::io::{Write as IoWrite, stdout};
 use std::path::Path;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -151,13 +151,13 @@ pub async fn monitor(config: MonitorConfig<'_>) -> Result<()> {
             match collect_device_stats(device).await {
                 Ok(stats) => {
                     // Check for alerts
-                    if let Some(temp_threshold) = config.temp_alert {
-                        if stats.temperature_celsius > temp_threshold {
-                            alerts.push(format!(
-                                "🌡️ {} temperature alert: {:.1}°C > {:.1}°C",
-                                device.name, stats.temperature_celsius, temp_threshold
-                            ));
-                        }
+                    if let Some(temp_threshold) = config.temp_alert
+                        && stats.temperature_celsius > temp_threshold
+                    {
+                        alerts.push(format!(
+                            "🌡️ {} temperature alert: {:.1}°C > {:.1}°C",
+                            device.name, stats.temperature_celsius, temp_threshold
+                        ));
                     }
 
                     if let Some(hashrate_threshold) = config.hashrate_alert {
@@ -284,7 +284,7 @@ pub async fn monitor(config: MonitorConfig<'_>) -> Result<()> {
             }
             OutputFormat::Text => {
                 use crate::output::{
-                    format_hashrate, format_power, format_table, format_uptime, ColoredTemperature,
+                    ColoredTemperature, format_hashrate, format_power, format_table, format_uptime,
                 };
                 use std::fmt::Write as FmtWrite;
                 use tabled::Tabled;
@@ -383,7 +383,10 @@ pub async fn monitor(config: MonitorConfig<'_>) -> Result<()> {
                 if config.type_summary {
                     writeln!(&mut output_buffer)?;
                     writeln!(&mut output_buffer, "📊 Device Type Summaries:")?;
-                    writeln!(&mut output_buffer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")?;
+                    writeln!(
+                        &mut output_buffer,
+                        "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+                    )?;
 
                     let type_summaries = cache.get_type_summaries();
                     {

--- a/src/discovery/mdns.rs
+++ b/src/discovery/mdns.rs
@@ -489,21 +489,31 @@ mod tests {
         let discovery = MdnsDiscovery::new();
 
         // Verify default services include expected ones
-        assert!(discovery
-            .service_names
-            .contains(&"_http._tcp.local.".to_string()));
-        assert!(discovery
-            .service_names
-            .contains(&"_https._tcp.local.".to_string()));
-        assert!(discovery
-            .service_names
-            .contains(&"_axeos._tcp.local.".to_string()));
-        assert!(discovery
-            .service_names
-            .contains(&"_bitaxe._tcp.local.".to_string()));
-        assert!(discovery
-            .service_names
-            .contains(&"_nerdqaxe._tcp.local.".to_string()));
+        assert!(
+            discovery
+                .service_names
+                .contains(&"_http._tcp.local.".to_string())
+        );
+        assert!(
+            discovery
+                .service_names
+                .contains(&"_https._tcp.local.".to_string())
+        );
+        assert!(
+            discovery
+                .service_names
+                .contains(&"_axeos._tcp.local.".to_string())
+        );
+        assert!(
+            discovery
+                .service_names
+                .contains(&"_bitaxe._tcp.local.".to_string())
+        );
+        assert!(
+            discovery
+                .service_names
+                .contains(&"_nerdqaxe._tcp.local.".to_string())
+        );
         assert_eq!(discovery.service_names.len(), 5);
     }
 

--- a/src/discovery/network.rs
+++ b/src/discovery/network.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use ipnetwork::{IpNetwork, Ipv4Network};
 use local_ip_address::local_ip;
 use std::net::{IpAddr, Ipv4Addr};
@@ -152,9 +152,11 @@ mod tests {
     fn test_get_fallback_networks() {
         let fallbacks = get_fallback_networks();
         assert!(!fallbacks.is_empty());
-        assert!(fallbacks
-            .iter()
-            .any(|net| net.to_string().contains("192.168.1.0")));
+        assert!(
+            fallbacks
+                .iter()
+                .any(|net| net.to_string().contains("192.168.1.0"))
+        );
     }
 
     #[test]

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::api::{AxeOsClient, Device, DeviceStatus, DeviceType};
-use crate::discovery::network::{get_network_addresses, NetworkInfo};
+use crate::discovery::network::{NetworkInfo, get_network_addresses};
 
 #[derive(Debug, Clone)]
 pub struct ScanResult {


### PR DESCRIPTION
## Summary
Migrates the project to Rust edition 2024, taking advantage of the latest language features and improvements.

## Changes
- 📦 Updated `Cargo.toml` to use `edition = "2024"`  
- 🔧 Applied automatic formatting from `cargo fmt`
- ✨ Fixed clippy warnings using edition 2024's let-else chains for cleaner conditional logic
- 🎯 No functional changes required - codebase was already compatible

## Technical Details
The migration primarily involved:
1. Updating the edition field in Cargo.toml
2. Running `cargo fix --edition` (no changes needed)
3. Fixing pre-existing clippy warnings about collapsible if statements using the new let-else chain syntax
4. Applying consistent formatting

## Testing
- [x] All 87 tests pass successfully
- [x] Project builds without errors
- [x] Clippy passes with no warnings
- [x] Code is properly formatted

## Benefits
- Access to latest Rust language features
- Improved pattern matching with let-else chains
- Better compile-time guarantees
- Staying current with Rust ecosystem

## Breaking Changes
None - this is a development-only change with no impact on functionality or API.