### PR TITLE
fix: update GitHub repository URLs from master to douglaz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,10 @@ jobs:
           
           ```bash
           # Using Nix
-          nix run 'git+https://github.com/master/axectl.git#${{ steps.get_tag.outputs.tag }}'
-          
+          nix run 'git+https://github.com/douglaz/axectl.git#${{ steps.get_tag.outputs.tag }}'
+
           # Using Cargo
-          cargo install --git https://github.com/master/axectl.git --tag ${{ steps.get_tag.outputs.tag }}
+          cargo install --git https://github.com/douglaz/axectl.git --tag ${{ steps.get_tag.outputs.tag }}
           ```
           
           ### Checksums

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "CLI tool for managing Bitaxe and NerdQAxe miners"
 license = "MIT"
-repository = "https://github.com/master/axectl"
+repository = "https://github.com/douglaz/axectl"
 
 [dependencies]
 # Core

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ axectl monitor --temp-alert 75 --hashrate-alert 10
 ## 📦 Installation
 
 ### Static Binary Downloads (Recommended)
-Download pre-built static binaries from the [releases page](https://github.com/master/axectl/releases).
+Download pre-built static binaries from the [releases page](https://github.com/douglaz/axectl/releases).
 
 **Linux users**: Download the musl static binary - it works on any Linux distribution without dependencies:
 ```bash
 # Download latest release (replace VERSION with actual version)
-curl -L -o axectl https://github.com/master/axectl/releases/download/vVERSION/axectl-x86_64-linux-musl.tar.gz
+curl -L -o axectl https://github.com/douglaz/axectl/releases/download/vVERSION/axectl-x86_64-linux-musl.tar.gz
 tar -xzf axectl-x86_64-linux-musl.tar.gz
 chmod +x axectl
 ./axectl --help
@@ -44,7 +44,7 @@ chmod +x axectl
 
 #### Quick Build (Static Binary)
 ```bash
-git clone https://github.com/master/axectl.git
+git clone https://github.com/douglaz/axectl.git
 cd axectl
 cargo build --release
 # Automatically builds static musl binary: ./target/x86_64-unknown-linux-musl/release/axectl
@@ -53,10 +53,10 @@ cargo build --release
 #### Using Nix (Recommended)
 ```bash
 # Run directly from GitHub
-nix run 'git+https://github.com/master/axectl.git'
+nix run 'git+https://github.com/douglaz/axectl.git'
 
 # Or build locally with proper toolchain
-git clone https://github.com/master/axectl.git
+git clone https://github.com/douglaz/axectl.git
 cd axectl
 nix develop  # Enters environment with musl toolchain
 cargo build --release  # Builds static binary by default
@@ -363,7 +363,7 @@ axectl is built with modularity and performance in mind:
 
 ```bash
 # Clone repository
-git clone https://github.com/master/axectl.git
+git clone https://github.com/douglaz/axectl.git
 cd axectl
 
 # Build with Nix (recommended)
@@ -423,8 +423,8 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## 🆘 Support
 
-- **Issues**: [GitHub Issues](https://github.com/master/axectl/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/master/axectl/discussions)
+- **Issues**: [GitHub Issues](https://github.com/douglaz/axectl/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/douglaz/axectl/discussions)
 - **Discord**: Join the [Bitaxe Community](https://discord.gg/3E8ca2dkcC)
 
 ---


### PR DESCRIPTION
## Summary

Updates all GitHub repository URLs in documentation and configuration files to use the correct repository path `douglaz/axectl` instead of `master/axectl`.

## Changes

- **Cargo.toml**: Updated repository field to `https://github.com/douglaz/axectl`
- **README.md**: Fixed all GitHub URLs for:
  - Release downloads
  - Repository cloning instructions
  - Nix run commands
  - GitHub Issues and Discussions links
- **.github/workflows/release.yml**: Updated installation instructions in release notes

## Impact

- Users will now be directed to the correct repository for all operations
- Release workflows will show correct installation commands
- Package metadata will point to the right repository

## Breaking Changes

None - this is a documentation and metadata fix only.