### PR TITLE
[codex] keep axectl.sh as the wrapper entrypoint

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -249,7 +249,7 @@ jobs:
         The bootstrap script will:
         - Automatically detect your platform
         - Download the appropriate binary
-        - Extract and install to \`~/.local/bin\`
+        - Extract and install to \`~/.local/share/axectl/bin\`
         - Check for updates periodically
         - Use local builds when available (for development)
         

--- a/axectl.sh
+++ b/axectl.sh
@@ -4,13 +4,17 @@ set -euo pipefail
 # Configuration
 REPO="douglaz/axectl"
 BINARY_NAME="axectl"
-INSTALL_DIR="${HOME}/.local/bin"
+DEFAULT_INSTALL_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/${BINARY_NAME}/bin"
+INSTALL_DIR="${AXECTL_INSTALL_DIR:-${DEFAULT_INSTALL_DIR}}"
 INSTALLED_VERSION_FILE="${INSTALL_DIR}/.${BINARY_NAME}.version"
+LAST_CHECK_FILE="${INSTALL_DIR}/.${BINARY_NAME}.last_check"
 # Determine script directory (only available when run as a file, not via stdin)
 if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    SCRIPT_PATH="${SCRIPT_DIR}/$(basename "${BASH_SOURCE[0]}")"
 else
     SCRIPT_DIR=""
+    SCRIPT_PATH=""
 fi
 
 # Platform detection
@@ -130,10 +134,18 @@ install_binary() {
         rm -rf "$temp_dir"
         exit 1
     fi
+
+    local target_path="${INSTALL_DIR}/${BINARY_NAME}"
+    if [[ "$target_path" == "$SCRIPT_PATH" ]]; then
+        echo "Error: Refusing to install ${BINARY_NAME} over the wrapper script." >&2
+        echo "Set AXECTL_INSTALL_DIR to a different directory." >&2
+        rm -rf "$temp_dir"
+        exit 1
+    fi
     
     # Make executable and move to install directory
     chmod +x "$binary_path"
-    mv "$binary_path" "${INSTALL_DIR}/${BINARY_NAME}"
+    mv "$binary_path" "$target_path"
     rm -rf "$temp_dir"
     
     # Record installed version
@@ -144,16 +156,14 @@ install_binary() {
 
 # Check for updates periodically (once per day)
 should_check_update() {
-    local check_file="${INSTALL_DIR}/.${BINARY_NAME}.last_check"
-    
     # Always check if binary doesn't exist
     if [[ ! -f "${INSTALL_DIR}/${BINARY_NAME}" ]]; then
         return 0
     fi
     
     # Check if we've checked recently
-    if [[ -f "$check_file" ]]; then
-        local last_check=$(stat -c %Y "$check_file" 2>/dev/null || stat -f %m "$check_file" 2>/dev/null || echo 0)
+    if [[ -f "$LAST_CHECK_FILE" ]]; then
+        local last_check=$(stat -c %Y "$LAST_CHECK_FILE" 2>/dev/null || stat -f %m "$LAST_CHECK_FILE" 2>/dev/null || echo 0)
         local current_time=$(date +%s)
         local day_in_seconds=86400
         
@@ -163,7 +173,7 @@ should_check_update() {
     fi
     
     # Mark that we're checking now
-    touch "$check_file"
+    touch "$LAST_CHECK_FILE"
     return 0
 }
 

--- a/axectl.sh
+++ b/axectl.sh
@@ -86,6 +86,16 @@ get_installed_version() {
     fi
 }
 
+would_overwrite_wrapper() {
+    local target_path="$1"
+
+    if [[ -z "$SCRIPT_PATH" || ! -e "$SCRIPT_PATH" || ! -e "$target_path" ]]; then
+        return 1
+    fi
+
+    [[ "$target_path" -ef "$SCRIPT_PATH" ]]
+}
+
 # Download and install binary
 install_binary() {
     local version="$1"
@@ -136,7 +146,7 @@ install_binary() {
     fi
 
     local target_path="${INSTALL_DIR}/${BINARY_NAME}"
-    if [[ "$target_path" == "$SCRIPT_PATH" ]]; then
+    if would_overwrite_wrapper "$target_path"; then
         echo "Error: Refusing to install ${BINARY_NAME} over the wrapper script." >&2
         echo "Set AXECTL_INSTALL_DIR to a different directory." >&2
         rm -rf "$temp_dir"


### PR DESCRIPTION
## What changed

- changed `axectl.sh` to install the managed binary under `~/.local/share/axectl/bin` by default instead of `~/.local/bin`
- added `AXECTL_INSTALL_DIR` support so the managed binary location can still be overridden explicitly
- kept the wrapper protection that refuses to install over the wrapper script itself
- updated the release workflow text to describe the new install location

## Why

The bootstrap wrapper is intended to stay on `PATH` as the stable entrypoint. Installing the managed binary into `~/.local/bin` lets it shadow a copied wrapper such as `~/bin/axectl`, which defeats the auto-updating wrapper model.

## Impact

Users who keep `axectl.sh` on `PATH` can continue using it as the wrapper while the downloaded binary lives in a private app-managed directory off `PATH`.

## Validation

- `bash -n axectl.sh`
- `shellcheck axectl.sh`
- pre-push hook: `cargo clippy --all-targets --all-features -- -D warnings`
